### PR TITLE
feat(frontend): add multi-column layout controls (1×/2×/3× + slider) …

### DIFF
--- a/frontend/src/components/Editor.css
+++ b/frontend/src/components/Editor.css
@@ -880,3 +880,41 @@
     transform: translateY(0);
   }
 }
+
+.columns-inline{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.columns-stepper{
+  display: flex;
+  gap: 6px;
+}
+.columns-range{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.columns-range input[type="range"]{ width: 140px; }
+.columns-value{ min-width: 1.5rem; text-align: right; }
+
+/* === Multi-column MVP === */
+.editor-columns {
+  column-count: var(--cols, 1);
+  column-gap: var(--col-gap, 2rem);
+}
+
+/* Evitar que bloques grandes se partan entre columnas */
+.break-inside-avoid,
+.editor-page img,
+.editor-page table,
+.editor-page pre {
+  break-inside: avoid;
+}
+
+/* Responsive: en pantallas chicas, 1 columna */
+@media (max-width: 640px) {
+  .editor-columns {
+    column-count: 1 !important;
+  }
+}

--- a/frontend/src/components/Editor.jsx
+++ b/frontend/src/components/Editor.jsx
@@ -20,7 +20,8 @@ function EditorCanvas({
   handleDrop,
   handleDragOver,
   handleDragLeave,
-  handleEditorClick
+  handleEditorClick,
+  columns = 1
 }) {
   return (
     <div className="editor-body">
@@ -35,7 +36,8 @@ function EditorCanvas({
       <div className="editor-canvas">
         <div
           ref={editorRef}
-          className="editor-page"
+          className="editor-page editor-columns"
+          style={{ '--cols': columns, '--col-gap': '2rem' }}
           data-page-size={pageSize}
           contentEditable
           suppressContentEditableWarning
@@ -78,6 +80,7 @@ function useEditor(docId) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [history, setHistory] = useState([]);
   const [redoStack, setRedoStack] = useState([]);
+  const [columns, setColumns] = useState(1); 
   const editorRef = useRef(null);
   const socketRef = useRef(null);
 
@@ -1406,6 +1409,8 @@ function useEditor(docId) {
     handleDragOver,
     handleDragLeave,
     handleEditorClick,
+    columns,
+    setColumns,
   };
 }
 

--- a/frontend/src/components/EditorToolbar.jsx
+++ b/frontend/src/components/EditorToolbar.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { getPageSizeOptions } from '../utils/pageSizes';
 // import './LatexRenderer';
 
-function EditorToolbar({ format, undo, redo, addPage, insertCodeBlock, activeFormats = [], clearFormatting, pages = [], currentPageIndex = 0, pageSize = 'a4', onPageSizeChange, updateActiveFormats, handleImageUpload, insertImage, convertToInlineCode }) {
-  // NOTE: document.execCommand is deprecated and may not work in all browsers. Consider migrating to a modern rich text editor library.
+function EditorToolbar({ format, undo, redo, addPage, insertCodeBlock, activeFormats = [], clearFormatting, pages = [], currentPageIndex = 0, pageSize = 'a4', onPageSizeChange, updateActiveFormats, handleImageUpload, insertImage, convertToInlineCode, columns = 1, onChangeColumns}) {
+// NOTE: document.execCommand is deprecated and may not work in all browsers. Consider migrating to a modern rich text editor library.
   const isActive = (cmd) => {
     const normalized = cmd.toLowerCase();
     return activeFormats.includes(normalized) || activeFormats.includes(`<${normalized}>`);
@@ -20,6 +20,11 @@ function EditorToolbar({ format, undo, redo, addPage, insertCodeBlock, activeFor
       setTimeout(updateActiveFormats, 0);
     }
   };
+ 
+ const setCols = (n) => {
+   const safe = Math.max(1, Math.min(6, n));
+   if (typeof onChangeColumns === 'function') onChangeColumns(safe);
+ };
 
   return (
     <div className="floating-toolbar-container">
@@ -352,7 +357,29 @@ function EditorToolbar({ format, undo, redo, addPage, insertCodeBlock, activeFor
             ))}
           </select>
         </div>
-        
+        <div className="toolbar-divider"></div>
+
+        {/* Columns Group (1–6) */}
+        <div className="toolbar-group columns-inline">
+          <div className="columns-stepper">
+            <button onMouseDown={(e)=>{e.preventDefault(); onChangeColumns(1)}}>1×</button>
+            <button onMouseDown={(e)=>{e.preventDefault(); onChangeColumns(2)}}>2×</button>
+            <button onMouseDown={(e)=>{e.preventDefault(); onChangeColumns(3)}}>3×</button>
+          </div>
+
+          <label className="columns-range" title="Número de columnas">
+            <span>Cols</span>
+            <input
+              type="range"
+              min="1"
+              max="6"
+              value={columns}
+              onChange={(e)=>onChangeColumns(Number(e.target.value))}
+            />
+            <span className="columns-value">{columns}</span>
+          </label>
+        </div>
+
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,3 +79,19 @@ code {
   right: 20px;
   z-index: 10;
 }
+
+/* === Multi-column MVP === */
+.editor-columns {
+  column-count: var(--cols, 1);
+  column-gap: var(--col-gap, 2rem);
+}
+
+.break-inside-avoid {
+  break-inside: avoid;
+}
+
+@media (max-width: 640px) {
+  .editor-columns {
+    column-count: 1 !important;
+  }
+}

--- a/frontend/src/pages/EditorPage.jsx
+++ b/frontend/src/pages/EditorPage.jsx
@@ -86,6 +86,8 @@ export default function EditorPage() {
     handleDragOver,
     handleDragLeave,
     handleEditorClick,
+    columns,
+    setColumns,
   } = useEditor(docId);
 
 
@@ -777,6 +779,8 @@ ORDER BY post_count DESC;`;
           handleImageUpload={handleImageUpload}
           insertImage={insertImage}
           convertToInlineCode={convertToInlineCode}
+          columns={columns}
+          onChangeColumns={setColumns}
         />
       </div>
 
@@ -800,6 +804,7 @@ ORDER BY post_count DESC;`;
           handleDragOver={handleDragOver}
           handleDragLeave={handleDragLeave}
           handleEditorClick={handleEditorClick}
+          columns={columns}
         />
       </main>
     </div>


### PR DESCRIPTION
Description of the issue: Add support for double column , triple column and so on 

Close #58 

This PR adds a simple multi-column layout control for the editor:

- Quick buttons: 1× / 2× / 3×
- Range slider: 1–6 columns
- Responsive: forces 1 column on narrow screens
- Prevents blocks (images/code) from breaking across columns

Scope: Frontend-only. No backend or config changes.


https://github.com/user-attachments/assets/c22a4e27-2d46-4b5b-93de-efb2fd8a3b5c

